### PR TITLE
Fix MODULE.bazel: remove use_repo entries for repos pub extension does not generate

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,31 +45,9 @@ pub.package(
 )
 use_repo(
     pub,
-    "pub_async",
-    "pub_boolean_selector",
-    "pub_characters",
-    "pub_clock",
-    "pub_collection",
-    "pub_fake_async",
     "pub_fixnum",
-    "pub_intl",
-    "pub_leak_tracker",
-    "pub_leak_tracker_flutter_testing",
-    "pub_leak_tracker_testing",
-    "pub_matcher",
-    "pub_material_color_utilities",
-    "pub_meta",
-    "pub_path",
     "pub_protobuf",
     "pub_protoc_plugin",
-    "pub_source_span",
-    "pub_stack_trace",
-    "pub_stream_channel",
-    "pub_string_scanner",
-    "pub_term_glyph",
-    "pub_test_api",
-    "pub_vector_math",
-    "pub_vm_service",
 )
 
 # Go dependencies for gazelle plugin


### PR DESCRIPTION
Fixes the strict `use_repo` validation error on Bazel 8 when any operation
walks the full module graph (`bazel mod graph`, IntelliJ Bazel sync, etc.):

```
ERROR: module extension @@rules_flutter+//flutter:extensions.bzl%pub does not
generate repository "pub_async", yet it is imported as "pub_async" in the
usage at @@rules_flutter+//:MODULE.bazel:30:20
```

The `pub` extension only generates `pub_fixnum`, `pub_protobuf`, and
`pub_protoc_plugin` (matching the three `pub.package(...)` calls earlier in
the file). The other 22 names listed in `use_repo` reference repos that
don't exist, which Bazel 8's stricter validation rejects.

This patch removes those 22 dead entries. It does not change the set of
repos actually generated by the extension, so it cannot break any code
path that previously worked.

Note: the `dart_proto_library` rule's `_path_pkg` attribute defaults to
`@pub_path//:path_files`, which is one of the 22 dangling references. That
rule is therefore unusable as-shipped — but addressing that requires either
adding the missing `pub.package(...)` declarations or restructuring how
consumers contribute packages, which is out of scope for this minimal fix.

Reproduced on Bazel 8.4.2.